### PR TITLE
fix: persist phone number across page refresh

### DIFF
--- a/frontend/src/AppContext.test.tsx
+++ b/frontend/src/AppContext.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { AppProvider, useAppContext } from './AppContext';
+
+function PhoneNumberProbe() {
+  const { phoneNumber, setPhoneNumber } = useAppContext();
+  return (
+    <div>
+      <span data-testid="phone">{phoneNumber ?? ''}</span>
+      <button onClick={() => setPhoneNumber('+31612345678')}>set</button>
+      <button onClick={() => setPhoneNumber('')}>clear</button>
+    </div>
+  );
+}
+
+describe('AppContext phone number persistence', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('persists the phone number to sessionStorage', () => {
+    render(
+      <AppProvider>
+        <PhoneNumberProbe />
+      </AppProvider>
+    );
+
+    act(() => {
+      screen.getByText('set').click();
+    });
+
+    expect(screen.getByTestId('phone').textContent).toBe('+31612345678');
+    expect(sessionStorage.getItem('phoneNumber')).toBe('+31612345678');
+  });
+
+  it('restores the phone number from sessionStorage on mount (e.g. after a refresh)', () => {
+    sessionStorage.setItem('phoneNumber', '+31612345678');
+
+    render(
+      <AppProvider>
+        <PhoneNumberProbe />
+      </AppProvider>
+    );
+
+    expect(screen.getByTestId('phone').textContent).toBe('+31612345678');
+  });
+
+  it('clears the stored phone number when set to an empty value', () => {
+    sessionStorage.setItem('phoneNumber', '+31612345678');
+
+    render(
+      <AppProvider>
+        <PhoneNumberProbe />
+      </AppProvider>
+    );
+
+    act(() => {
+      screen.getByText('clear').click();
+    });
+
+    expect(screen.getByTestId('phone').textContent).toBe('');
+    expect(sessionStorage.getItem('phoneNumber')).toBeNull();
+  });
+});

--- a/frontend/src/AppContext.tsx
+++ b/frontend/src/AppContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useState, ReactNode } from "react";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  ReactNode,
+} from "react";
 
 // Define the shape of the context state
 interface AppContextType {
@@ -35,7 +41,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   // Persist the phone number so it survives a page reload. The phone number is
   // not sensitive enough to warrant special handling, and sessionStorage is
   // cleared when the tab is closed, scoping it to the current session.
-  const setPhoneNumber = (value: string) => {
+  const setPhoneNumber = useCallback((value: string) => {
     setPhoneNumberState(value);
     try {
       if (value) {
@@ -46,7 +52,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
     } catch {
       // Ignore storage errors (e.g. private mode); state still works in-memory.
     }
-  };
+  }, []);
 
   return (
     <AppContext.Provider value={{ phoneNumber, setPhoneNumber }}>

--- a/frontend/src/AppContext.tsx
+++ b/frontend/src/AppContext.tsx
@@ -14,9 +14,39 @@ interface AppProviderProps {
   children: ReactNode;
 }
 
+// Key used to persist the phone number across page reloads (e.g. when the user
+// refreshes the Cloudflare verification page).
+const PHONE_NUMBER_STORAGE_KEY = "phoneNumber";
+
+const readStoredPhoneNumber = (): string | undefined => {
+  try {
+    return sessionStorage.getItem(PHONE_NUMBER_STORAGE_KEY) ?? undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 // Provider component
 export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
-  const [phoneNumber, setPhoneNumber] = useState<string | undefined>();
+  const [phoneNumber, setPhoneNumberState] = useState<string | undefined>(
+    readStoredPhoneNumber
+  );
+
+  // Persist the phone number so it survives a page reload. The phone number is
+  // not sensitive enough to warrant special handling, and sessionStorage is
+  // cleared when the tab is closed, scoping it to the current session.
+  const setPhoneNumber = (value: string) => {
+    setPhoneNumberState(value);
+    try {
+      if (value) {
+        sessionStorage.setItem(PHONE_NUMBER_STORAGE_KEY, value);
+      } else {
+        sessionStorage.removeItem(PHONE_NUMBER_STORAGE_KEY);
+      }
+    } catch {
+      // Ignore storage errors (e.g. private mode); state still works in-memory.
+    }
+  };
 
   return (
     <AppContext.Provider value={{ phoneNumber, setPhoneNumber }}>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
@@ -6,6 +7,11 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
     ],
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      setupFiles: './src/setupTests.ts',
+    },
     server: mode === 'development' ? {
       port: 3000,
       host: "0.0.0.0",


### PR DESCRIPTION
## Problem

Closes #27.

When a user enters a phone number, submits, and reaches the Cloudflare bot-detection page, refreshing the page after Cloudflare validation emptied the phone number field. Clicking **Next** afterwards led to the error page.

## Cause

The phone number was stored only in in-memory React context (`AppContext`). A page reload resets that state to `undefined`, so the (disabled) phone input on the validation page rendered empty, and `ValidatePage` redirects to `/error` when `phoneNumber` is missing on submit. The enroll step is affected the same way.

## Fix

Persist the phone number to `sessionStorage` from `AppContext`:
- Initialize state from `sessionStorage` on mount, so a refresh restores the value.
- Write through on `setPhoneNumber`, and remove the key when cleared (e.g. after successful issuance).
- Storage access is wrapped in try/catch so private-mode/blocked-storage falls back to in-memory behaviour.

`sessionStorage` scopes the value to the current tab/session and clears it when the tab closes.

## Tests

Wired up a jsdom-based vitest config (deps and `setupTests.ts` were already present but not configured) and added tests covering persistence, restore-on-mount after a refresh, and clearing.